### PR TITLE
Add image support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ updated to include the page_id of the generated root page. Be sure to commit
 ## Not supported
 
 - Relative links
-- Media files
 
 ## Roadmap
 

--- a/pkg/publish.go
+++ b/pkg/publish.go
@@ -1,12 +1,17 @@
 package dox
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
+	"io"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/jesselang/go-confluence"
 	"github.com/spf13/viper"
-
+	"golang.org/x/net/html"
 	"github.com/jesselang/dox/pkg/source"
 )
 
@@ -77,7 +82,23 @@ func Publish(file string, rootID string, dryRun bool) (id string, err error) {
 			return "", err
 		}
 
+		imageSrcFiles := GetImageSrcFiles(c.Body.Storage.Value, file)
+		if len(imageSrcFiles) != 0 {
+			c.Body.Storage.Value, err = ReplaceImagesWithAttachments(imageSrcFiles, file, c.Body.Storage.Value, c.ID, wiki, uri)
+			if err != nil {
+				return "", err
+			}
+
+			c.Version.Number += 1
+			c, err = wiki.UpdateContent(c)
+			if err != nil {
+				return "", err
+			}
+		}
+
 	} else {
+		newPageContent := src.Output()
+
 		c, err = wiki.GetContent(src.ID(),
 			[]string{"body.storage", "space", "version"})
 		if err != nil {
@@ -85,8 +106,14 @@ func Publish(file string, rootID string, dryRun bool) (id string, err error) {
 			return "", err
 		}
 
-		if c.Body.Storage.Value != src.Output() {
-			c.Body.Storage.Value = src.Output()
+		imageSrcFiles := GetImageSrcFiles(newPageContent, file)
+		newPageContent, err = ReplaceImagesWithAttachments(imageSrcFiles, file, newPageContent, c.ID, wiki, uri)
+		if err != nil {
+			return "", err
+		}
+
+		if c.Body.Storage.Value != newPageContent {
+			c.Body.Storage.Value = newPageContent
 			c.Version.Number += 1
 
 			c, err = wiki.UpdateContent(c)
@@ -96,4 +123,105 @@ func Publish(file string, rootID string, dryRun bool) (id string, err error) {
 		}
 	}
 	return c.ID, nil
+}
+
+func GetImageSrcsFromHTML(content string) []string {
+	var imageSrcs []string
+	z := html.NewTokenizer(strings.NewReader(content))
+	for {
+		tt := z.Next()
+		t := z.Token()
+		switch tt {
+		case html.ErrorToken:
+			return imageSrcs
+		case html.SelfClosingTagToken:
+			if t.Data == "img" {
+				for _, attr := range t.Attr {
+					if attr.Key == "src" {
+						imageSrcs = append(imageSrcs, attr.Val)
+					}
+				}
+			}
+		}
+	}
+	return imageSrcs
+}
+
+func GetImageSrcFiles(content string, file string) []string {
+	fileDir := filepath.Dir(file)
+	imageSrcs := GetImageSrcsFromHTML(content)
+
+	var imageSrcFiles []string
+
+	for _, imageSrc := range imageSrcs {
+		imageSrcPath := filepath.Join(fileDir, imageSrc)
+		if _, err := os.Stat(imageSrcPath); !os.IsNotExist(err) {
+			imageSrcFiles = append(imageSrcFiles, imageSrc)
+		}
+	}
+
+	return imageSrcFiles
+}
+
+func ReplaceImagesWithAttachments(imageSrcFiles []string, file string, pageContent string, pageID string, wiki *confluence.Wiki, uri string) (string, error) {
+	for _, imageSrcFile := range imageSrcFiles {
+		fileDir := filepath.Dir(file)
+		imageSrcPath := filepath.Join(fileDir, imageSrcFile)
+		imageSrcFilename := filepath.Base(imageSrcPath)
+
+		results, err := wiki.GetAttachment(pageID, imageSrcFilename)
+		if err != nil {
+			return "", err
+		}
+
+		if len(results.Results) == 0 {
+			// create new attachment
+			_, err := wiki.CreateAttachment(pageID, imageSrcPath)
+			if err != nil {
+				return "", err
+			}
+		} else {
+			// update existing attachment
+			imageData, err := wiki.GetAttachmentData(pageID, imageSrcFilename)
+			if err != nil {
+				return "", err
+			}
+
+			attachmentSum := getBytesSha256(imageData)
+			fileSum, err := getFileSha256(imageSrcPath)
+			if err != nil {
+				return "", err
+			}
+
+			if fileSum != attachmentSum {
+				_, err := wiki.UpdateAttachment(pageID, imageSrcPath, results.Results[0].ID)
+				if err != nil {
+					return "", err
+				}
+			}
+		}
+
+		pageContent = strings.Replace(pageContent, "\"" + imageSrcFile + "\"", "\"" + uri + "/download/attachments/" + pageID + "/" + imageSrcFilename + "\"", -1)
+	}
+
+	return pageContent, nil
+}
+
+func getFileSha256(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func getBytesSha256(b []byte) string {
+	h := sha256.New()
+	h.Write(b)
+	return hex.EncodeToString(h.Sum(nil))
 }

--- a/pkg/publish.go
+++ b/pkg/publish.go
@@ -135,7 +135,7 @@ func Publish(file string, rootID string, dryRun bool) (id string, err error) {
 	return c.ID, nil
 }
 
-func GetImageSrcsFromHTML(content string) ([]string, error) {
+func getImageSrcsFromHTML(content string) ([]string, error) {
 	var imageSrcs []string
 	z := html.NewTokenizer(strings.NewReader(content))
 	for {
@@ -162,7 +162,7 @@ func GetImageSrcsFromHTML(content string) ([]string, error) {
 	return imageSrcs, nil
 }
 
-func GetImageSrcFiles(content string, file string) ([]string, error) {
+func getImageSrcFiles(content string, file string) ([]string, error) {
 	fileDir := filepath.Dir(file)
 	imageSrcs, err := GetImageSrcsFromHTML(content)
 	if err != nil {
@@ -188,7 +188,7 @@ func GetImageSrcFiles(content string, file string) ([]string, error) {
 	return imageSrcFiles, nil
 }
 
-func ReplaceImagesWithAttachments(imageSrcFiles []string, file string, pageContent string, pageID string, wiki *confluence.Wiki, uri string) (string, error) {
+func replaceImagesWithAttachments(imageSrcFiles []string, file string, pageContent string, pageID string, wiki *confluence.Wiki, uri string) (string, error) {
 	for _, imageSrcFile := range imageSrcFiles {
 		fileDir := filepath.Dir(file)
 		imageSrcPath := filepath.Join(fileDir, imageSrcFile)

--- a/pkg/publish.go
+++ b/pkg/publish.go
@@ -84,13 +84,13 @@ func Publish(file string, rootID string, dryRun bool) (id string, err error) {
 			return "", err
 		}
 
-		imageSrcFiles, err := GetImageSrcFiles(c.Body.Storage.Value, file)
+		imageSrcFiles, err := getImageSrcFiles(c.Body.Storage.Value, file)
 		if err != nil {
 			return "", err
 		}
 
 		if len(imageSrcFiles) != 0 {
-			c.Body.Storage.Value, err = ReplaceImagesWithAttachments(imageSrcFiles, file, c.Body.Storage.Value, c.ID, wiki, uri)
+			c.Body.Storage.Value, err = replaceImagesWithAttachments(imageSrcFiles, file, c.Body.Storage.Value, c.ID, wiki, uri)
 			if err != nil {
 				return "", err
 			}
@@ -112,12 +112,12 @@ func Publish(file string, rootID string, dryRun bool) (id string, err error) {
 			return "", err
 		}
 
-		imageSrcFiles, err := GetImageSrcFiles(sourceOutput, file)
+		imageSrcFiles, err := getImageSrcFiles(sourceOutput, file)
 		if err != nil {
 			return "", err
 		}
 
-		pageContent, err := ReplaceImagesWithAttachments(imageSrcFiles, file, sourceOutput, c.ID, wiki, uri)
+		pageContent, err := replaceImagesWithAttachments(imageSrcFiles, file, sourceOutput, c.ID, wiki, uri)
 		if err != nil {
 			return "", err
 		}
@@ -164,7 +164,7 @@ func getImageSrcsFromHTML(content string) ([]string, error) {
 
 func getImageSrcFiles(content string, file string) ([]string, error) {
 	fileDir := filepath.Dir(file)
-	imageSrcs, err := GetImageSrcsFromHTML(content)
+	imageSrcs, err := getImageSrcsFromHTML(content)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add support for Markdown files that contain images using additions in jesselang/go-confluence to create and update attachments. 

Companion pull request: https://github.com/jesselang/go-confluence/pull/8