### PR TITLE
Add relative linking support

### DIFF
--- a/.dox.yaml
+++ b/.dox.yaml
@@ -1,3 +1,4 @@
 uri: http://localhost:8090
 space: DEMO
 title: "dox: publish docs from your repos"
+browse_url_base: https://github.com/jesselang/dox/blob/master

--- a/README.md
+++ b/README.md
@@ -32,14 +32,11 @@ Each markdown file will be modified with a dox header, and `.dox.yaml` will be
 updated to include the page_id of the generated root page. Be sure to commit
 `.dox.yaml` and these changes to markdown in your source code management.
 
-## Not supported
-
-- Relative links
+<!-- ## Not supported -->
 
 ## Roadmap
 
 - Improve [go-confluence][go-confluence] error handling
-- Relative links
 - Media files
 - `dox update` updates already published files without source modifications
 - `dox init` to create initial config

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ cat - <<EOF > .dox.yaml
 uri: https://confluence.yourcompany.com
 space: DEMO
 title: "title of generated root page"
+browse_url_base: https://github.com/jesselang/dox/blob/master
 EOF
 
 # set DOX_USERNAME and DOX_PASSWORD to appropriate values
@@ -31,6 +32,25 @@ dox will publish **all markdown files** as children of a generated root page.
 Each markdown file will be modified with a dox header, and `.dox.yaml` will be
 updated to include the page_id of the generated root page. Be sure to commit
 `.dox.yaml` and these changes to markdown in your source code management.
+
+### Relative Linking
+
+Websites like github allow markdown files to relatively link to other files in
+the repository. dox will try to replicate this functionality by changing
+relative links it finds in pages to be published.
+
+If the relative link points to a dox source file, it will change that link to
+the URL for that published page (currently limited to Confluence). Otherwise,
+dox will change the link to the file's browse URL using `browse_url_base`.
+
+`browse_url_base` supports formatting using the `%s` verb:
+
+```
+# dox appends '/%s'
+browse_url_base: https://github.com/jesselang/dox/blob/master
+
+browse_url_base: https://othersourcesite.com/repo-base/browse/%s?format=raw
+```
 
 <!-- ## Not supported -->
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,28 +34,32 @@ to quickly create a Cobra application.`,
 			os.Exit(1)
 		}
 
-		root, err := dox.Publish("", "", repoRoot, dryRun) // generated root page
+		_, err = dox.PrePublish("", "", dryRun) // generate blank root page
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error: %s\n", err)
 			os.Exit(1)
 		}
+
+		root, err := dox.Publish("", "", dryRun) // generate populated root page
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %s\n", err)
+			os.Exit(1)
+		}
+
 		if verbose {
 			fmt.Printf("root published to %s\n", root)
 		}
 
 		for _, v := range files {
-			_, err := dox.Publish(v, root, repoRoot, dryRun)
+			_, err := dox.PrePublish(v, root, dryRun)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "error: %s\n", err)
 				os.Exit(1)
 			}
 		}
 
-		// ham-fisted approach to ensuring that all relative links are linked
-		// correctly, first pass above cannot guarantee that all pages were
-		// already created when executed
 		for _, v := range files {
-			id, err := dox.Publish(v, root, repoRoot, dryRun)
+			id, err := dox.Publish(v, repoRoot, dryRun)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "error: %s\n", err)
 				os.Exit(1)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,7 +34,7 @@ to quickly create a Cobra application.`,
 			os.Exit(1)
 		}
 
-		root, err := dox.Publish("", "", dryRun) // generated root page
+		root, err := dox.Publish("", "", repoRoot, dryRun) // generated root page
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error: %s\n", err)
 			os.Exit(1)
@@ -44,7 +44,18 @@ to quickly create a Cobra application.`,
 		}
 
 		for _, v := range files {
-			id, err := dox.Publish(v, root, dryRun)
+			_, err := dox.Publish(v, root, repoRoot, dryRun)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "error: %s\n", err)
+				os.Exit(1)
+			}
+		}
+
+		// ham-fisted approach to ensuring that all relative links are linked
+		// correctly, first pass above cannot guarantee that all pages were
+		// already created when executed
+		for _, v := range files {
+			id, err := dox.Publish(v, root, repoRoot, dryRun)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "error: %s\n", err)
 				os.Exit(1)

--- a/pkg/publish.go
+++ b/pkg/publish.go
@@ -1,23 +1,15 @@
 package dox
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
-	"fmt"
-	"io"
 	"os"
-	"net/url"
-	"path/filepath"
-	"strings"
 
 	"github.com/jesselang/go-confluence"
 	"github.com/spf13/viper"
-	"golang.org/x/net/html"
 	"github.com/jesselang/dox/pkg/source"
 )
 
-func Publish(file string, rootID string, dryRun bool) (id string, err error) {
+func Publish(file string, rootID string, repoRoot string, dryRun bool) (id string, err error) {
 	uri := viper.GetString("uri")
 	if len(uri) == 0 {
 		return id, errors.New("uri must be set in config")
@@ -26,6 +18,11 @@ func Publish(file string, rootID string, dryRun bool) (id string, err error) {
 	space := viper.GetString("space")
 	if len(space) == 0 {
 		return id, errors.New("space must be set in config")
+	}
+
+	repoBrowseURL := viper.GetString("repo_browse_url")
+	if len(repoBrowseURL) == 0 {
+		return id, errors.New("repo_browse_url must be set in config")
 	}
 
 	username := os.Getenv("DOX_USERNAME")
@@ -84,13 +81,13 @@ func Publish(file string, rootID string, dryRun bool) (id string, err error) {
 			return "", err
 		}
 
-		imageSrcFiles, err := getImageSrcFiles(c.Body.Storage.Value, file)
+		imageSrcFiles, err := GetImageSrcFiles(c.Body.Storage.Value, file)
 		if err != nil {
 			return "", err
 		}
 
 		if len(imageSrcFiles) != 0 {
-			c.Body.Storage.Value, err = replaceImagesWithAttachments(imageSrcFiles, file, c.Body.Storage.Value, c.ID, wiki, uri)
+			c.Body.Storage.Value, err = ReplaceImagesWithAttachments(imageSrcFiles, file, c.Body.Storage.Value, c.ID, wiki, uri)
 			if err != nil {
 				return "", err
 			}
@@ -112,12 +109,17 @@ func Publish(file string, rootID string, dryRun bool) (id string, err error) {
 			return "", err
 		}
 
-		imageSrcFiles, err := getImageSrcFiles(sourceOutput, file)
+		imageSrcFiles, err := GetImageSrcFiles(sourceOutput, file)
 		if err != nil {
 			return "", err
 		}
 
-		pageContent, err := replaceImagesWithAttachments(imageSrcFiles, file, sourceOutput, c.ID, wiki, uri)
+		pageContent, err := ReplaceImagesWithAttachments(imageSrcFiles, file, sourceOutput, c.ID, wiki, uri)
+		if err != nil {
+			return "", err
+		}
+
+		pageContent, err = ReplaceRelativeLinks(file, pageContent, uri, repoBrowseURL, repoRoot)
 		if err != nil {
 			return "", err
 		}
@@ -133,120 +135,4 @@ func Publish(file string, rootID string, dryRun bool) (id string, err error) {
 		}
 	}
 	return c.ID, nil
-}
-
-func getImageSrcsFromHTML(content string) ([]string, error) {
-	var imageSrcs []string
-	z := html.NewTokenizer(strings.NewReader(content))
-	for {
-		tokenType := z.Next()
-		token := z.Token()
-
-		switch tokenType {
-		case html.ErrorToken:
-			if z.Err() != io.EOF {
-				return nil, z.Err()
-			} else {
-				return imageSrcs, nil
-			}
-		case html.SelfClosingTagToken:
-			if token.Data == "img" {
-				for _, attr := range token.Attr {
-					if attr.Key == "src" {
-						imageSrcs = append(imageSrcs, attr.Val)
-					}
-				}
-			}
-		}
-	}
-	return imageSrcs, nil
-}
-
-func getImageSrcFiles(content string, file string) ([]string, error) {
-	fileDir := filepath.Dir(file)
-	imageSrcs, err := getImageSrcsFromHTML(content)
-	if err != nil {
-		return nil, err
-	}
-
-	var imageSrcFiles []string
-
-	for _, imageSrc := range imageSrcs {
-		// skip imageSrcs that are URLs
-		if _, err := url.ParseRequestURI(imageSrc); err == nil {
-			continue
-		}
-
-		imageSrcPath := filepath.Join(fileDir, imageSrc)
-		if _, err := os.Stat(imageSrcPath); !os.IsNotExist(err) {
-			imageSrcFiles = append(imageSrcFiles, imageSrc)
-		} else {
-			fmt.Printf("warn: could not find image file %s\n", imageSrcPath)
-		}
-	}
-
-	return imageSrcFiles, nil
-}
-
-func replaceImagesWithAttachments(imageSrcFiles []string, file string, pageContent string, pageID string, wiki *confluence.Wiki, uri string) (string, error) {
-	for _, imageSrcFile := range imageSrcFiles {
-		fileDir := filepath.Dir(file)
-		imageSrcPath := filepath.Join(fileDir, imageSrcFile)
-		imageSrcFilename := filepath.Base(imageSrcPath)
-
-		results, err := wiki.GetAttachment(pageID, imageSrcFilename)
-		if err != nil {
-			return "", err
-		}
-
-		if len(results.Results) == 0 {
-			// create new attachment
-			_, err := wiki.CreateAttachment(pageID, imageSrcPath)
-			if err != nil {
-				return "", err
-			}
-		} else {
-			// update existing attachment
-			imageData, err := wiki.GetAttachmentData(pageID, imageSrcFilename)
-			if err != nil {
-				return "", err
-			}
-
-			attachmentSum := getBytesSha256(imageData)
-			fileSum, err := getFileSha256(imageSrcPath)
-			if err != nil {
-				return "", err
-			}
-
-			if fileSum != attachmentSum {
-				_, err := wiki.UpdateAttachment(pageID, imageSrcPath, results.Results[0].ID)
-				if err != nil {
-					return "", err
-				}
-			}
-		}
-
-		pageContent = strings.Replace(pageContent, fmt.Sprintf(`"%s"`, imageSrcFile), fmt.Sprintf(`"%s/download/attachments/%s/%s"`, uri, pageID, imageSrcFilename), -1)
-	}
-
-	return pageContent, nil
-}
-
-func getFileSha256(path string) (string, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return "", err
-	}
-	defer f.Close()
-	h := sha256.New()
-	if _, err := io.Copy(h, f); err != nil {
-		return "", err
-	}
-	return hex.EncodeToString(h.Sum(nil)), nil
-}
-
-func getBytesSha256(b []byte) string {
-	h := sha256.New()
-	h.Write(b)
-	return hex.EncodeToString(h.Sum(nil))
 }

--- a/pkg/publish.go
+++ b/pkg/publish.go
@@ -9,30 +9,46 @@ import (
 	"github.com/jesselang/dox/pkg/source"
 )
 
-func Publish(file string, rootID string, repoRoot string, dryRun bool) (id string, err error) {
-	uri := viper.GetString("uri")
+var uri string
+var space string
+var browseUrlBase string
+var username string
+var password string
+
+func getConfigVars() error {
+	uri = viper.GetString("uri")
 	if len(uri) == 0 {
-		return id, errors.New("uri must be set in config")
+		return errors.New("uri must be set in config")
 	}
 
-	space := viper.GetString("space")
+	space = viper.GetString("space")
 	if len(space) == 0 {
-		return id, errors.New("space must be set in config")
+		return errors.New("space must be set in config")
 	}
 
-	browseUrlBase := viper.GetString("browse_url_base")
+	browseUrlBase = viper.GetString("browse_url_base")
 	if len(browseUrlBase) == 0 {
-		return id, errors.New("browse_url_base must be set in config")
+		return errors.New("browse_url_base must be set in config")
 	}
 
-	username := os.Getenv("DOX_USERNAME")
+	username = os.Getenv("DOX_USERNAME")
 	if len(username) == 0 {
-		return id, errors.New("DOX_USERNAME must be set")
+		return errors.New("DOX_USERNAME must be set")
 	}
 
-	password := os.Getenv("DOX_PASSWORD")
+	password = os.Getenv("DOX_PASSWORD")
 	if len(password) == 0 {
-		return id, errors.New("DOX_PASSWORD must be set")
+		return errors.New("DOX_PASSWORD must be set")
+	}
+
+	return nil
+}
+
+// Creates pages if they don't exist
+func PrePublish(file string, rootID string, dryRun bool) (id string, err error) {
+	err = getConfigVars()
+	if err != nil {
+		return id, err
 	}
 
 	wiki, err := confluence.NewWiki(
@@ -51,88 +67,99 @@ func Publish(file string, rootID string, repoRoot string, dryRun bool) (id strin
 		return
 	}
 
-	var c *confluence.Content
+	if dryRun || src.ID() != "" {
+		return src.ID(), nil
+	}
+
+	// NEW
+	c := &confluence.Content{
+		ID:    src.ID(),
+		Type:  "page",
+		Title: src.Title(),
+	}
+
+	if rootID != "" {
+		c.Ancestors = []confluence.ContentAncestor{{ID: rootID}}
+	}
+	c.Body.Storage.Value = "This is a page stub created by dox."
+	c.Body.Storage.Representation = "storage"
+	c.Space.Key = space
+	c.Version.Number = 1
+
+	c, err = wiki.CreateContent(c)
+	if err != nil {
+		// TODO: confluence does not support duplicate title in a space
+		return "", err
+	}
+
+	err = src.SetID(c.ID)
+	if err != nil {
+		return "", err
+	}
+
+	return src.ID(), nil
+}
+
+// Updates page content
+func Publish(file string, repoRoot string, dryRun bool) (id string, err error) {
+	err = getConfigVars()
+	if err != nil {
+		return id, err
+	}
+
+	wiki, err := confluence.NewWiki(
+		uri,
+		confluence.BasicAuth(
+			username,
+			password,
+		),
+	)
+	if err != nil {
+		return
+	}
+
+	src, err := source.New(file, source.Opts{StripComments: true, TrimSpace: true})
+	if err != nil {
+		return
+	}
+
 	if dryRun {
 		return src.ID(), nil
-	} else if src.ID() == "" {
-		// NEW
-		c = &confluence.Content{
-			ID:    src.ID(),
-			Type:  "page",
-			Title: src.Title(),
-		}
+	}
 
-		if rootID != "" {
-			c.Ancestors = []confluence.ContentAncestor{{ID: rootID}}
-		}
-		c.Body.Storage.Value = src.Output()
-		c.Body.Storage.Representation = "storage"
-		c.Space.Key = space
-		c.Version.Number = 1
+	sourceOutput := src.Output()
 
-		c, err = wiki.CreateContent(c)
-		if err != nil {
-			// TODO: confluence does not support duplicate title in a space
-			return "", err
-		}
+	c, err := wiki.GetContent(src.ID(),
+		[]string{"body.storage", "space", "version"})
+	if err != nil {
+		// TODO: handle 404 where dox id exists in source, but published page does not
+		return "", err
+	}
 
-		err = src.SetID(c.ID)
-		if err != nil {
-			return "", err
-		}
+	imageSrcFiles, err := getImageSrcFiles(sourceOutput, file)
+	if err != nil {
+		return "", err
+	}
 
-		imageSrcFiles, err := getImageSrcFiles(c.Body.Storage.Value, file)
-		if err != nil {
-			return "", err
-		}
+	pageContent, err := replaceImagesWithAttachments(imageSrcFiles, file, sourceOutput, c.ID, wiki, uri)
+	if err != nil {
+		return "", err
+	}
 
-		if len(imageSrcFiles) != 0 {
-			c.Body.Storage.Value, err = replaceImagesWithAttachments(imageSrcFiles, file, c.Body.Storage.Value, c.ID, wiki, uri)
-			if err != nil {
-				return "", err
-			}
+	pageContent, err = replaceRelativeLinks(file, pageContent, uri, browseUrlBase, repoRoot)
+	if err != nil {
+		return "", err
+	}
 
-			c.Version.Number += 1
-			c, err = wiki.UpdateContent(c)
-			if err != nil {
-				return "", err
-			}
-		}
+	if c.Body.Storage.Value != pageContent {
+		c.Body.Storage.Value = pageContent
+		c.Version.Number += 1
 
-	} else {
-		sourceOutput := src.Output()
-
-		c, err = wiki.GetContent(src.ID(),
-			[]string{"body.storage", "space", "version"})
-		if err != nil {
-			// TODO: handle 404 where dox id exists in source, but published page does not
-			return "", err
-		}
-
-		imageSrcFiles, err := getImageSrcFiles(sourceOutput, file)
+		c, err = wiki.UpdateContent(c)
 		if err != nil {
 			return "", err
-		}
-
-		pageContent, err := replaceImagesWithAttachments(imageSrcFiles, file, sourceOutput, c.ID, wiki, uri)
-		if err != nil {
-			return "", err
-		}
-
-		pageContent, err = replaceRelativeLinks(file, pageContent, uri, browseUrlBase, repoRoot)
-		if err != nil {
-			return "", err
-		}
-
-		if c.Body.Storage.Value != pageContent {
-			c.Body.Storage.Value = pageContent
-			c.Version.Number += 1
-
-			c, err = wiki.UpdateContent(c)
-			if err != nil {
-				return "", err
-			}
 		}
 	}
+
 	return c.ID, nil
 }

--- a/pkg/publish.go
+++ b/pkg/publish.go
@@ -20,9 +20,9 @@ func Publish(file string, rootID string, repoRoot string, dryRun bool) (id strin
 		return id, errors.New("space must be set in config")
 	}
 
-	repoBrowseURL := viper.GetString("repo_browse_url")
-	if len(repoBrowseURL) == 0 {
-		return id, errors.New("repo_browse_url must be set in config")
+	browseUrlBase := viper.GetString("browse_url_base")
+	if len(browseUrlBase) == 0 {
+		return id, errors.New("browse_url_base must be set in config")
 	}
 
 	username := os.Getenv("DOX_USERNAME")
@@ -119,7 +119,7 @@ func Publish(file string, rootID string, repoRoot string, dryRun bool) (id strin
 			return "", err
 		}
 
-		pageContent, err = replaceRelativeLinks(file, pageContent, uri, repoBrowseURL, repoRoot)
+		pageContent, err = replaceRelativeLinks(file, pageContent, uri, browseUrlBase, repoRoot)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/publish.go
+++ b/pkg/publish.go
@@ -81,13 +81,13 @@ func Publish(file string, rootID string, repoRoot string, dryRun bool) (id strin
 			return "", err
 		}
 
-		imageSrcFiles, err := GetImageSrcFiles(c.Body.Storage.Value, file)
+		imageSrcFiles, err := getImageSrcFiles(c.Body.Storage.Value, file)
 		if err != nil {
 			return "", err
 		}
 
 		if len(imageSrcFiles) != 0 {
-			c.Body.Storage.Value, err = ReplaceImagesWithAttachments(imageSrcFiles, file, c.Body.Storage.Value, c.ID, wiki, uri)
+			c.Body.Storage.Value, err = replaceImagesWithAttachments(imageSrcFiles, file, c.Body.Storage.Value, c.ID, wiki, uri)
 			if err != nil {
 				return "", err
 			}
@@ -109,17 +109,17 @@ func Publish(file string, rootID string, repoRoot string, dryRun bool) (id strin
 			return "", err
 		}
 
-		imageSrcFiles, err := GetImageSrcFiles(sourceOutput, file)
+		imageSrcFiles, err := getImageSrcFiles(sourceOutput, file)
 		if err != nil {
 			return "", err
 		}
 
-		pageContent, err := ReplaceImagesWithAttachments(imageSrcFiles, file, sourceOutput, c.ID, wiki, uri)
+		pageContent, err := replaceImagesWithAttachments(imageSrcFiles, file, sourceOutput, c.ID, wiki, uri)
 		if err != nil {
 			return "", err
 		}
 
-		pageContent, err = ReplaceRelativeLinks(file, pageContent, uri, repoBrowseURL, repoRoot)
+		pageContent, err = replaceRelativeLinks(file, pageContent, uri, repoBrowseURL, repoRoot)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/publish_images.go
+++ b/pkg/publish_images.go
@@ -42,7 +42,7 @@ func getImageSrcsFromHTML(content string) ([]string, error) {
 	return imageSrcs, nil
 }
 
-func GetImageSrcFiles(content string, file string) ([]string, error) {
+func getImageSrcFiles(content string, file string) ([]string, error) {
 	fileDir := filepath.Dir(file)
 	imageSrcs, err := getImageSrcsFromHTML(content)
 	if err != nil {
@@ -68,7 +68,7 @@ func GetImageSrcFiles(content string, file string) ([]string, error) {
 	return imageSrcFiles, nil
 }
 
-func ReplaceImagesWithAttachments(imageSrcFiles []string, file string, pageContent string, pageID string, wiki *confluence.Wiki, uri string) (string, error) {
+func replaceImagesWithAttachments(imageSrcFiles []string, file string, pageContent string, pageID string, wiki *confluence.Wiki, uri string) (string, error) {
 	fileDir := filepath.Dir(file)
 	for _, imageSrcFile := range imageSrcFiles {
 		imageSrcPath := filepath.Join(fileDir, imageSrcFile)

--- a/pkg/publish_images.go
+++ b/pkg/publish_images.go
@@ -1,0 +1,132 @@
+package dox
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"net/url"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/net/html"
+	"github.com/jesselang/go-confluence"
+
+)
+
+func getImageSrcsFromHTML(content string) ([]string, error) {
+	var imageSrcs []string
+	z := html.NewTokenizer(strings.NewReader(content))
+	for {
+		tokenType := z.Next()
+		token := z.Token()
+
+		switch tokenType {
+		case html.ErrorToken:
+			if z.Err() != io.EOF {
+				return nil, z.Err()
+			} else {
+				return imageSrcs, nil
+			}
+		case html.SelfClosingTagToken:
+			if token.Data == "img" {
+				for _, attr := range token.Attr {
+					if attr.Key == "src" {
+						imageSrcs = append(imageSrcs, attr.Val)
+					}
+				}
+			}
+		}
+	}
+	return imageSrcs, nil
+}
+
+func GetImageSrcFiles(content string, file string) ([]string, error) {
+	fileDir := filepath.Dir(file)
+	imageSrcs, err := getImageSrcsFromHTML(content)
+	if err != nil {
+		return nil, err
+	}
+
+	var imageSrcFiles []string
+
+	for _, imageSrc := range imageSrcs {
+		// skip imageSrcs that are URLs
+		if _, err := url.ParseRequestURI(imageSrc); err == nil {
+			continue
+		}
+
+		imageSrcPath := filepath.Join(fileDir, imageSrc)
+		if _, err := os.Stat(imageSrcPath); !os.IsNotExist(err) {
+			imageSrcFiles = append(imageSrcFiles, imageSrc)
+		} else {
+			fmt.Printf("warn: could not find image file %s\n", imageSrcPath)
+		}
+	}
+
+	return imageSrcFiles, nil
+}
+
+func ReplaceImagesWithAttachments(imageSrcFiles []string, file string, pageContent string, pageID string, wiki *confluence.Wiki, uri string) (string, error) {
+	fileDir := filepath.Dir(file)
+	for _, imageSrcFile := range imageSrcFiles {
+		imageSrcPath := filepath.Join(fileDir, imageSrcFile)
+		imageSrcFilename := filepath.Base(imageSrcPath)
+
+		results, err := wiki.GetAttachment(pageID, imageSrcFilename)
+		if err != nil {
+			return "", err
+		}
+
+		if len(results.Results) == 0 {
+			// create new attachment
+			_, err := wiki.CreateAttachment(pageID, imageSrcPath)
+			if err != nil {
+				return "", err
+			}
+		} else {
+			// update existing attachment
+			imageData, err := wiki.GetAttachmentData(pageID, imageSrcFilename)
+			if err != nil {
+				return "", err
+			}
+
+			attachmentSum := getBytesSha256(imageData)
+			fileSum, err := getFileSha256(imageSrcPath)
+			if err != nil {
+				return "", err
+			}
+
+			if fileSum != attachmentSum {
+				_, err := wiki.UpdateAttachment(pageID, imageSrcPath, results.Results[0].ID)
+				if err != nil {
+					return "", err
+				}
+			}
+		}
+
+		pageContent = strings.Replace(pageContent, fmt.Sprintf(`"%s"`, imageSrcFile), fmt.Sprintf(`"%s/download/attachments/%s/%s"`, uri, pageID, imageSrcFilename), -1)
+	}
+
+	return pageContent, nil
+}
+
+func getFileSha256(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func getBytesSha256(b []byte) string {
+	h := sha256.New()
+	h.Write(b)
+	return hex.EncodeToString(h.Sum(nil))
+}

--- a/pkg/publish_links.go
+++ b/pkg/publish_links.go
@@ -65,7 +65,14 @@ func getLocalLinkedAnchors(content string, file string) ([]string, error) {
 	return localAnchorHrefs, nil
 }
 
-func replaceRelativeLinks(file string, pageContent string, uri string, repoBrowseURL string, repoRoot string) (string, error) {
+func replaceRelativeLinks(file string, pageContent string, uri string, browseUrlBase string, repoRoot string) (string, error) {
+	if !strings.Contains(browseUrlBase, "%s") {
+		if !strings.HasSuffix(browseUrlBase, "/") {
+			browseUrlBase += "/"
+		}
+		browseUrlBase += "%s"
+	}
+
 	localAnchorHrefs, err := getLocalLinkedAnchors(pageContent, file)
 	if err != nil {
 		return "", err
@@ -80,8 +87,8 @@ func replaceRelativeLinks(file string, pageContent string, uri string, repoBrows
 			// file exists but is not a dox source file, link to source instead
 			localAnchorHrefFromRepoRoot := strings.Replace(localAnchorHrefPath, repoRoot, "", -1)
 			localAnchorHrefFromRepoRoot = strings.TrimPrefix(localAnchorHrefFromRepoRoot, "/")
-			pageContent = strings.Replace(pageContent, fmt.Sprintf(`href="%s"`, localAnchorHref), fmt.Sprintf(`href="%s/%s"`, repoBrowseURL, localAnchorHrefFromRepoRoot), -1)
-			continue
+			sourceUrl := fmt.Sprintf(browseUrlBase, localAnchorHrefFromRepoRoot)
+			pageContent = strings.Replace(pageContent, fmt.Sprintf(`href="%s"`, localAnchorHref), fmt.Sprintf(`href="%s"`, sourceUrl), -1)
 		} else if src.ID() != "" {
 			pageContent = strings.Replace(pageContent, fmt.Sprintf(`href="%s"`, localAnchorHref), fmt.Sprintf(`href="%s"`, confluenceUrlForPageID(uri, src.ID())), -1)
 		}

--- a/pkg/publish_links.go
+++ b/pkg/publish_links.go
@@ -65,7 +65,7 @@ func getLocalLinkedAnchors(content string, file string) ([]string, error) {
 	return localAnchorHrefs, nil
 }
 
-func ReplaceRelativeLinks(file string, pageContent string, uri string, repoBrowseURL string, repoRoot string) (string, error) {
+func replaceRelativeLinks(file string, pageContent string, uri string, repoBrowseURL string, repoRoot string) (string, error) {
 	localAnchorHrefs, err := getLocalLinkedAnchors(pageContent, file)
 	if err != nil {
 		return "", err

--- a/pkg/publish_links.go
+++ b/pkg/publish_links.go
@@ -66,6 +66,8 @@ func getLocalLinkedAnchors(content string, file string) ([]string, error) {
 }
 
 func replaceRelativeLinks(file string, pageContent string, uri string, browseUrlBase string, repoRoot string) (string, error) {
+	// The user can supply a string verb for formatting. If the verb is not
+	// present, append it to the end of the URL
 	if !strings.Contains(browseUrlBase, "%s") {
 		if !strings.HasSuffix(browseUrlBase, "/") {
 			browseUrlBase += "/"

--- a/pkg/publish_links.go
+++ b/pkg/publish_links.go
@@ -1,0 +1,95 @@
+package dox
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"net/url"
+	"path/filepath"
+	"strings"
+
+	"github.com/jesselang/dox/pkg/source"
+	"golang.org/x/net/html"
+)
+
+func getAnchorHrefsFromHTML(content string) ([]string, error) {
+	var anchorHrefs []string
+	z := html.NewTokenizer(strings.NewReader(content))
+	for {
+		tokenType := z.Next()
+		token := z.Token()
+
+		switch tokenType {
+		case html.ErrorToken:
+			if z.Err() != io.EOF {
+				return nil, z.Err()
+			} else {
+				return anchorHrefs, nil
+			}
+		case html.StartTagToken:
+			if token.Data == "a" {
+				for _, attr := range token.Attr {
+					if attr.Key == "href" {
+						anchorHrefs = append(anchorHrefs, attr.Val)
+					}
+				}
+			}
+		}
+	}
+	return anchorHrefs, nil
+}
+
+func getLocalLinkedAnchors(content string, file string) ([]string, error) {
+	fileDir := filepath.Dir(file)
+	anchorHrefs, err := getAnchorHrefsFromHTML(content)
+	if err != nil {
+		return nil, err
+	}
+
+	var localAnchorHrefs []string
+
+	for _, anchorHref := range anchorHrefs {
+		// skip anchorHrefs that are URLs
+		if _, err := url.ParseRequestURI(anchorHref); err == nil {
+			continue
+		}
+
+		anchorHrefPath := filepath.Join(fileDir, anchorHref)
+		if _, err := os.Stat(anchorHrefPath); !os.IsNotExist(err) {
+			localAnchorHrefs = append(localAnchorHrefs, anchorHref)
+		} else {
+			fmt.Printf("warn: could not find file %s\n", anchorHrefPath)
+		}
+	}
+
+	return localAnchorHrefs, nil
+}
+
+func ReplaceRelativeLinks(file string, pageContent string, uri string, repoBrowseURL string, repoRoot string) (string, error) {
+	localAnchorHrefs, err := getLocalLinkedAnchors(pageContent, file)
+	if err != nil {
+		return "", err
+	}
+
+	fileDir := filepath.Dir(file)
+	for _, localAnchorHref := range localAnchorHrefs {
+		localAnchorHrefPath := filepath.Join(fileDir, localAnchorHref)
+
+		src, err := source.New(localAnchorHrefPath, source.Opts{StripComments: true, TrimSpace: true})
+		if err != nil {
+			// file exists but is not a dox source file, link to source instead
+			localAnchorHrefFromRepoRoot := strings.Replace(localAnchorHrefPath, repoRoot, "", -1)
+			localAnchorHrefFromRepoRoot = strings.TrimPrefix(localAnchorHrefFromRepoRoot, "/")
+			pageContent = strings.Replace(pageContent, fmt.Sprintf(`href="%s"`, localAnchorHref), fmt.Sprintf(`href="%s/%s"`, repoBrowseURL, localAnchorHrefFromRepoRoot), -1)
+			continue
+		} else if src.ID() != "" {
+			pageContent = strings.Replace(pageContent, fmt.Sprintf(`href="%s"`, localAnchorHref), fmt.Sprintf(`href="%s"`, confluenceUrlForPageID(uri, src.ID())), -1)
+		}
+	}
+
+	return pageContent, nil
+}
+
+func confluenceUrlForPageID(uri, pageID string) string {
+	return fmt.Sprintf("%s/pages/viewpage.action?pageId=%s", uri, pageID)
+}


### PR DESCRIPTION
- ham-fisted approach to relative linking
- if a link is a dox source file, change the link to a Confluence URL with page ID
- if a link is a file, change the link to point to repo_browse_url