### PR TITLE
Add edit notice to top of published pages

### DIFF
--- a/pkg/publish.go
+++ b/pkg/publish.go
@@ -122,7 +122,11 @@ func Publish(file string, repoRoot string, dryRun bool) (id string, err error) {
 		return
 	}
 
-	src, err := source.New(file, source.Opts{StripComments: true, TrimSpace: true})
+	src, err := source.New(file, source.Opts{
+		StripComments: true,
+		TrimSpace: true,
+		DoxNoticeFileUrl: fileBrowseUrl(browseUrlBase, repoRoot, file),
+	})
 	if err != nil {
 		return
 	}

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -6,10 +6,12 @@ import (
 
 const doxIdFmt = "dox: %s"
 const doxIgnore = "dox: ignore"
+const doxOmitNotice = "dox: omit-notice"
 
 type Opts struct {
-	StripComments bool
-	TrimSpace     bool
+	StripComments    bool
+	TrimSpace        bool
+	DoxNoticeFileUrl string
 }
 
 type source interface {


### PR DESCRIPTION
Add a Confluence macro which states that users should not edit the page, but edit the source file. The notice can be optionally excluded with a new directive `dox: omit_notice` in a dox source file.