### PR TITLE
source/markdown: relax title parsing requirement for ignored files

### DIFF
--- a/pkg/source/markdown.go
+++ b/pkg/source/markdown.go
@@ -208,8 +208,8 @@ func (m *markdown) parse(filename string, opts Opts) (err error) {
 		}
 	}
 
-	if m.title == "" {
-		return errors.New("title not found")
+	if !m.ignore && m.title == "" {
+		return fmt.Errorf("%s: title not found", filename)
 	}
 
 	rest, err := ioutil.ReadAll(r)


### PR DESCRIPTION
No need to require title parsing for ignored files and have `dox` terminate with an error.