### PR TITLE
Trying to publish markdown files in vendor folder

### DIFF
--- a/internal/find.go
+++ b/internal/find.go
@@ -23,6 +23,10 @@ func walk(path string, info os.FileInfo, err error) error {
 		return filepath.SkipDir
 	}
 
+	if name == "vendor" {
+		return filepath.SkipDir
+	}
+
 	if info.IsDir() {
 		return nil
 	}


### PR DESCRIPTION
For golang based projects which have vendoring enabled, dox tries to list and publish markdown files in the vendor folder.

The fix skips the directory if the dir name is `vendor` .